### PR TITLE
modify login response to enable codegen to generate header based client

### DIFF
--- a/src/apis/authentication_api.py
+++ b/src/apis/authentication_api.py
@@ -35,7 +35,18 @@ router = APIRouter()
 @router.post(
     "/auth/login",
     responses={
-        200: {"description": "Success"},
+        200: {
+            "description": "Success", 
+            "headers": { 
+                "X-Auth-Token": {
+                    "schema":{
+                        "type": "string"
+                    },
+                    "description": "header containing the auth token"
+                } 
+            },
+            "content": None
+        },
         401: {"description": "Unauthorized"},
     },
     tags=["Authentication"],

--- a/src/security_api.py
+++ b/src/security_api.py
@@ -43,8 +43,4 @@ def get_password_hash(password: string):
     return hashed_password
 
 def verify_password_hash(password: string, password_hash: string):
-    try:
-        pwd_context.verify(password, password_hash)
-    except UnknownHashError as e:
-        return False
-    return True
+    return pwd_context.verify(password, password_hash)


### PR DESCRIPTION
The codegen we are using does not support 204 as response code due to a weird bug. So we need  to use 200 but no content so that it generates a client service which returns a header.
Have raised an MR with fix: https://github.com/ferdikoomen/openapi-typescript-codegen/pull/1965